### PR TITLE
add blacklist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 julia:
   - 1.0
+  - 1.3
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: julia
 os:
   - linux
   - osx
+  - windows
 julia:
-  - 1.0
   - 1.3
   - nightly
 matrix:
@@ -18,7 +18,7 @@ after_success:
 jobs:
   include:
     - stage: Documentation
-      julia: 1.0
+      julia: 1.3
       script: julia --project=docs -e '
           using Pkg;
           Pkg.develop(PackageSpec(path=pwd()));

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -4,12 +4,10 @@
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BenchmarkTools]]
-deps = ["JSON", "Printf", "Statistics"]
-git-tree-sha1 = "85abcf0c5c9c24de45173e190200b62e97574a7c"
-repo-rev = "ox/balloc"
-repo-url = "https://github.com/oxinabox/BenchmarkTools.jl.git"
+deps = ["JSON", "Logging", "Printf", "Statistics", "UUIDs"]
+git-tree-sha1 = "9e62e66db34540a0c919d72172cc2f642ac71260"
 uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-version = "0.4.3"
+version = "0.5.0"
 
 [[Cassette]]
 git-tree-sha1 = "f6a148cadd38ba328bd2c03442037ef801a6aa05"
@@ -65,6 +63,9 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
@@ -82,6 +83,10 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/src/replaying.jl
+++ b/src/replaying.jl
@@ -48,7 +48,8 @@ const WHITE_LIST = [
     Base.iterate,
     Broadcast.broadcasted, Broadcast.instantiate,
     Broadcast.preprocess, Base.not_int,
-    Base.size
+    Base.size,
+    Tuple,
 ]
 
 for F in WHITE_LIST

--- a/src/replaying.jl
+++ b/src/replaying.jl
@@ -21,7 +21,6 @@ end
 end
 @inline next_scheduled_alloc!(ctx::ReplayCtx) = next_scheduled_alloc!(ctx.metadata)
 
-
 @inline function Cassette.overdub(
     ctx::ReplayCtx, ::Type{Array{T,N}}, ::UndefInitializer, dims
 )::Array{T,N} where {T,N}
@@ -41,6 +40,21 @@ end
     return scheduled
 end
 
+
+const WHITE_LIST = [
+    Base.promote_op, Base.to_shape,
+    Core.getfield,
+    Core.:(===),
+    Base.iterate,
+    Broadcast.broadcasted, Broadcast.instantiate,
+    Broadcast.preprocess, Base.not_int,
+    Base.size
+]
+
+for F in WHITE_LIST
+    @eval @inline Cassette.overdub(ctx::RecordingCtx, f::typeof($F), xs...) = f(xs...)
+    @eval @inline Cassette.overdub(ctx::ReplayCtx, f::typeof($F), xs...) = f(xs...)
+end
 
 function avoid_allocations(record, f, args...; kwargs...)
     ctx = new_replay_ctx(record)

--- a/src/replaying.jl
+++ b/src/replaying.jl
@@ -41,18 +41,18 @@ end
 end
 
 
-const WHITE_LIST = [
+const BLACK_LIST = [
     Base.promote_op, Base.to_shape,
     Core.getfield,
     Core.:(===),
     Base.iterate,
-    Broadcast.broadcasted, Broadcast.instantiate,
+    Broadcast.broadcasted,
     Broadcast.preprocess, Base.not_int,
     Base.size,
     Tuple,
 ]
 
-for F in WHITE_LIST
+for F in BLACK_LIST
     @eval @inline Cassette.overdub(ctx::RecordingCtx, f::typeof($F), xs...) = f(xs...)
     @eval @inline Cassette.overdub(ctx::ReplayCtx, f::typeof($F), xs...) = f(xs...)
 end

--- a/test/integration_tests.jl
+++ b/test/integration_tests.jl
@@ -16,5 +16,5 @@ end
 @testset "matmul example" begin
     @assert (@ballocated f_matmul()) === 18_304
     val, record = record_allocations(f_matmul)
-    @test (@ballocated avoid_allocations($record, f_matmul)) == 352
+    @test (@ballocated avoid_allocations($record, f_matmul)) == 256
 end

--- a/test/integration_tests.jl
+++ b/test/integration_tests.jl
@@ -16,5 +16,6 @@ end
 @testset "matmul example" begin
     @assert (@ballocated f_matmul()) === 18_304
     val, record = record_allocations(f_matmul)
-    @test (@ballocated avoid_allocations($record, f_matmul)) == 256
+    # NOTE: (@Roger-luo) not sure why this is 256 on my machine
+    @test (@ballocated avoid_allocations($record, f_matmul)) <= 352
 end


### PR DESCRIPTION
as described in #5 I think this at least will solve some for loop slow down due to type inference failure in `iterate` etc. But I haven't investigated much in this direction.