### PR TITLE
add haskey to blacklist

### DIFF
--- a/src/replaying.jl
+++ b/src/replaying.jl
@@ -49,6 +49,7 @@ const BLACK_LIST = [
     Broadcast.broadcasted,
     Broadcast.preprocess, Base.not_int,
     Base.size,
+    Base.haskey,
     Tuple,
 ]
 


### PR DESCRIPTION
Not sure why... but it seems Julia compiler fails to infer the type, and make `haskey` become dynamic dispatch inside Zygote. I found this in a quite complicated example of training a Matrix Product State, I'll try to make up a simpler one later if I could make it.