### PR TITLE
workaround some more type inference issue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 BenchmarkTools = "0.5"

--- a/src/replaying.jl
+++ b/src/replaying.jl
@@ -40,6 +40,7 @@ end
     return scheduled
 end
 
+using LinearAlgebra
 
 const BLACK_LIST = [
     Base.promote_op, Base.to_shape,

--- a/src/replaying.jl
+++ b/src/replaying.jl
@@ -47,9 +47,13 @@ const BLACK_LIST = [
     Core.:(===),
     Base.iterate,
     Broadcast.broadcasted,
-    Broadcast.preprocess, Base.not_int,
+    Broadcast.preprocess,
+    Broadcast.combine_axes,
+    Base.not_int,
     Base.size,
     Base.haskey,
+    Base.reduced_indices,
+    LinearAlgebra.gemv!,
     Tuple,
 ]
 
@@ -57,6 +61,12 @@ for F in BLACK_LIST
     @eval @inline Cassette.overdub(ctx::RecordingCtx, f::typeof($F), xs...) = f(xs...)
     @eval @inline Cassette.overdub(ctx::ReplayCtx, f::typeof($F), xs...) = f(xs...)
 end
+
+@inline Cassette.overdub(ctx::RecordingCtx, ::Type{Val}, x) = Val(x)
+@inline Cassette.overdub(ctx::ReplayCtx, ::Type{Val}, x) = Val(x)
+
+@inline Cassette.overdub(ctx::RecordingCtx, ::typeof(getindex), x::IdDict, key) = getindex(x, key)
+@inline Cassette.overdub(ctx::ReplayCtx, ::typeof(getindex), x::IdDict, key) = getindex(x, key)
 
 function avoid_allocations(record, f, args...; kwargs...)
     ctx = new_replay_ctx(record)


### PR DESCRIPTION
I found these using Cthulhu.jl

it seems I blacklisted `Broadcast.instanitiate` because of `Broadcast.combine_axes`, which is the actual type infer failed case inside Broadcast somehow.