### PR TITLE
make preallocate thread-safe & allow recursive preallocation

### DIFF
--- a/src/inference_fixes.jl
+++ b/src/inference_fixes.jl
@@ -32,5 +32,5 @@ end
 @inline Cassette.overdub(ctx::RecordingCtx, ::typeof(getindex), x::IdDict, key) = getindex(x, key)
 @inline Cassette.overdub(ctx::ReplayCtx, ::typeof(getindex), x::IdDict, key) = getindex(x, key)
 
-@inline Cassette.overdub(ctx::RecordingCtx, f::PreallocatedFunction, xs...) = f(xs...)
-@inline Cassette.overdub(ctx::ReplayCtx, f::PreallocatedFunction, xs...) = f(xs...)
+@inline Cassette.overdub(ctx::RecordingCtx, ::typeof(Cassette.overdub), ctx2::RecordingCtx, f::PreallocatedFunction, xs...) = Cassette.overdub(ctx2, f, xs...)
+@inline Cassette.overdub(ctx::ReplayCtx, ::typeof(Cassette.overdub), ctx2::ReplayCtx, f::PreallocatedFunction, xs...) = Cassette.overdub(ctx2, f, xs...)

--- a/src/inference_fixes.jl
+++ b/src/inference_fixes.jl
@@ -14,6 +14,11 @@ const BLACK_LIST = (
     Base.reduced_indices,
     LinearAlgebra.gemv!,
     Tuple,
+    # skip all AutoPreallocation APIs
+    preallocate,
+    avoid_allocations,
+    freeze,
+    record_allocations,
 )
 
 for F in BLACK_LIST
@@ -26,3 +31,6 @@ end
 
 @inline Cassette.overdub(ctx::RecordingCtx, ::typeof(getindex), x::IdDict, key) = getindex(x, key)
 @inline Cassette.overdub(ctx::ReplayCtx, ::typeof(getindex), x::IdDict, key) = getindex(x, key)
+
+@inline Cassette.overdub(ctx::RecordingCtx, f::PreallocatedFunction, xs...) = f(xs...)
+@inline Cassette.overdub(ctx::ReplayCtx, f::PreallocatedFunction, xs...) = f(xs...)

--- a/src/replaying.jl
+++ b/src/replaying.jl
@@ -55,7 +55,6 @@ end
     return quote
         if haskey(f.ctx[Threads.threadid()], $xs)
             ctx = f.ctx[Threads.threadid()][$xs]
-            # step = ctx.metadata.step::Ref{Int}
             ctx.metadata.step[] = 1
             return Cassette.overdub(ctx, f.f, xs...)
         else

--- a/src/replaying.jl
+++ b/src/replaying.jl
@@ -47,21 +47,21 @@ end
 
 struct PreallocatedFunction{F}
     f::F
-    ctx::Dict{Tuple, ReplayCtx}  # maps from argument types to the ReplayCtx
-    PreallocatedFunction(f) = new{typeof(f)}(f, Dict{Tuple, ReplayCtx}())
+    ctx::Vector{Dict{Tuple, ReplayCtx}}  # maps from argument types to the ReplayCtx
+    PreallocatedFunction(f) = new{typeof(f)}(f, [Dict{Tuple, ReplayCtx}() for _ in 1:Threads.nthreads()])
 end
 
 @generated function (f::PreallocatedFunction)(xs...)
     return quote
-        if haskey(f.ctx, $xs)
-            ctx = f.ctx[$xs]
+        if haskey(f.ctx[Threads.threadid()], $xs)
+            ctx = f.ctx[Threads.threadid()][$xs]
             # step = ctx.metadata.step::Ref{Int}
             ctx.metadata.step[] = 1
             return Cassette.overdub(ctx, f.f, xs...)
         else
             x, record = record_allocations(f.f, xs...)
             ctx = AutoPreallocation.new_replay_ctx(record)
-            f.ctx[$xs] = ctx
+            f.ctx[Threads.threadid()][$xs] = ctx
             return x
         end
     end


### PR DESCRIPTION
I'm wondering if it's better to just `copy` the records for other threads instead re-tracing them in other threads?

update: for recursive preallocation, a better way it to append the records to the upper level record, I'll make another PR to do this later. but I just let it skip the inner record for now in this PR.