### PR TITLE
rm old preallocated generic function & add preallocated method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ os:
 julia:
   - 1.3
   - nightly
+env:
+  - JULIA_NUM_THREADS=4
 matrix:
   allow_failures:
     - julia: nightly

--- a/src/AutoPreallocation.jl
+++ b/src/AutoPreallocation.jl
@@ -9,5 +9,6 @@ include("recording.jl")
 include("replaying.jl")
 include("inference_fixes.jl")
 include("no_prealloc.jl")
+include("preallocate.jl")
 
 end # module

--- a/src/preallocate.jl
+++ b/src/preallocate.jl
@@ -2,10 +2,10 @@ export preallocate
 
 struct PreallocatedMethod{F, Args <: Tuple, N, R}
     f::F
-    ctx::NTuple{N, R}
+    replay_ctxs::NTuple{N, R} # one replay context per thread
 
-    function PreallocatedMethod{F, Args}(f::F, ctx::NTuple{N, R}) where {F, Args, N, R}
-        new{F, Args, N, R}(f, ctx)
+    function PreallocatedMethod{F, Args}(f::F, ctxs::NTuple{N, R}) where {F, Args, N, R}
+        new{F, Args, N, R}(f, ctxs)
     end
 end
 
@@ -18,7 +18,7 @@ function PreallocatedMethod(f::F, xs...) where F
 end
 
 function (f::PreallocatedMethod)(xs...)
-    ctx = f.ctx[Threads.threadid()]
+    ctx = f.replay_ctxs[Threads.threadid()]
     # RL: Why this is not type stable at all?
     step = getfield(ctx.metadata, :step)::Base.RefValue{Int}
     setindex!(step, 1)::Base.RefValue{Int}

--- a/src/preallocate.jl
+++ b/src/preallocate.jl
@@ -9,15 +9,6 @@ struct PreallocatedMethod{F, Args <: Tuple, N, R}
     end
 end
 
-function PreallocatedMethod(f::F, xs...) where F
-    x, record = record_allocations(f, xs...)
-    record = freeze(record)
-    ctxs = ntuple(Threads.nthreads()) do ii
-        new_replay_ctx(ii == 1 ? record : copy(record))
-    end
-    return PreallocatedMethod{F, typeof(xs)}(f, ctxs)
-end
-
 function (f::PreallocatedMethod)(xs...)
     ctx = f.replay_ctxs[Threads.threadid()]
     ctx.metadata.step[] = 1

--- a/src/preallocate.jl
+++ b/src/preallocate.jl
@@ -19,9 +19,7 @@ end
 
 function (f::PreallocatedMethod)(xs...)
     ctx = f.replay_ctxs[Threads.threadid()]
-    # RL: Why this is not type stable at all?
-    step = getfield(ctx.metadata, :step)::Base.RefValue{Int}
-    setindex!(step, 1)::Base.RefValue{Int}
+    ctx.metadata.step[] = 1
     return Cassette.overdub(ctx, f.f, xs...)
 end
 

--- a/src/preallocate.jl
+++ b/src/preallocate.jl
@@ -1,0 +1,52 @@
+export preallocate
+
+struct PreallocatedMethod{F, Args <: Tuple, N, R}
+    f::F
+    ctx::NTuple{N, R}
+
+    function PreallocatedMethod{F, Args}(f::F, ctx::NTuple{N, R}) where {F, Args, N, R}
+        new{F, Args, N, R}(f, ctx)
+    end
+end
+
+function PreallocatedMethod(f::F, xs...) where F
+    x, record = record_allocations(f, xs...)
+    record = freeze(record)
+    records = (ntuple(_->copy(record), Threads.nthreads() - 1)..., record)
+    ctx = new_replay_ctx.(records)
+    return PreallocatedMethod{F, typeof(xs)}(f, ctx)
+end
+
+function (f::PreallocatedMethod)(xs...)
+    ctx = f.ctx[Threads.threadid()]
+    # RL: Why this is not type stable at all?
+    step = getfield(ctx.metadata, :step)::Base.RefValue{Int}
+    setindex!(step, 1)::Base.RefValue{Int}
+    return Cassette.overdub(ctx, f.f, xs...)
+end
+
+"""
+    preallocate(f, xs...)
+
+Return the first run result and a preallocated version of the corresponding method of
+callable object `f` given its argument. Note the behaviour of both the method generated record
+and the method will be freezed, you shouldn't feed this function with a dynamic allocation
+method.
+"""
+function preallocate(f::F, xs...) where F
+    x, record = record_allocations(f, xs...)
+    record = freeze(record)
+    records = (ntuple(_->copy(record), Threads.nthreads() - 1)..., record)
+    ctx = new_replay_ctx.(records)
+    return x, PreallocatedMethod{F, typeof(xs)}(f, ctx)
+end
+
+function Base.show(io::IO, f::PreallocatedMethod{F, Args}) where {F, Args}
+    print(io, "preallocate(", f.f)
+
+    for each in Args.parameters
+        print(io, ", ::", each)
+    end
+
+    print(io, ")")
+end

--- a/src/record_types.jl
+++ b/src/record_types.jl
@@ -15,11 +15,11 @@ function FrozenAllocationRecord(record)
 end
 
 function Base.copy(record::AllocationRecord)
-    return AllocationRecord(copy(record.allocations), copy(record.initial_sizes))
+    return AllocationRecord(copy.(record.allocations), record.initial_sizes)
 end
 
 function Base.copy(record::FrozenAllocationRecord)
-    return FrozenAllocationRecord(copy(record.allocations), copy(record.initial_sizes))
+    return FrozenAllocationRecord(copy.(record.allocations), record.initial_sizes)
 end
 
 """

--- a/src/record_types.jl
+++ b/src/record_types.jl
@@ -14,6 +14,14 @@ function FrozenAllocationRecord(record)
     return FrozenAllocationRecord(Tuple(record.allocations), Tuple(record.initial_sizes))
 end
 
+function Base.copy(record::AllocationRecord)
+    return AllocationRecord(copy(record.allocations), copy(record.initial_sizes))
+end
+
+function Base.copy(record::FrozenAllocationRecord)
+    return FrozenAllocationRecord(copy(record.allocations), copy(record.initial_sizes))
+end
+
 """
     freeze(record)
 

--- a/src/replaying.jl
+++ b/src/replaying.jl
@@ -1,6 +1,6 @@
 struct AllocationReplay{A}
     allocations::A
-    step::Ref{Int}
+    step::Base.RefValue{Int}
 end
 
 AllocationReplay(record) = AllocationReplay(record.allocations, Ref(1))

--- a/test/integration_tests.jl
+++ b/test/integration_tests.jl
@@ -37,7 +37,7 @@ end
     results = Vector{Any}(undef, 4)
     As = [rand(4, 4) for _ in 1:4]
     Bs = [rand(4, 4) for _ in 1:4]
-    _, pf = preallocate(As[1], Bs[1])
+    _, pf = preallocate(f, As[1], Bs[1])
     Threads.@threads for k in 1:4
         results[k] = pf(As[k], Bs[k])
     end

--- a/test/integration_tests.jl
+++ b/test/integration_tests.jl
@@ -35,13 +35,17 @@ end
 @testset "check thread-safe" begin
     f(x, y) = x * y
     results = Vector{Any}(undef, 4)
-    A, B = (rand(4, 4) for _ in 1:2)
-    _, pf = preallocate(A, B)
+    As = [rand(4, 4) for _ in 1:4]
+    Bs = [rand(4, 4) for _ in 1:4]
+    _, pf = preallocate(As[1], Bs[1])
     Threads.@threads for k in 1:4
-        results[k] = pf(A, B)
+        results[k] = pf(As[k], Bs[k])
     end
 
+    # if it's not thread-safe, the result
+    # will be modified by other multiplications
+    # since they will share the same memory
     for k in 1:4
-        @test results[k] ≈ f(A, B)
+        @test results[k] ≈ f(As[k], Bs[k])
     end
 end

--- a/test/integration_tests.jl
+++ b/test/integration_tests.jl
@@ -31,3 +31,17 @@ end
     @test record.initial_sizes == [(32, 64), (32, 2)]
     @test (@ballocated avoid_allocations($record, f_matmul_noprealloc)) <= 1520
 end
+
+@testset "check thread-safe" begin
+    f(x, y) = x * y
+    results = Vector{Any}(undef, 4)
+    A, B = (rand(4, 4) for _ in 1:2)
+    _, pf = preallocate(A, B)
+    Threads.@threads for k in 1:4
+        results[k] = pf(A, B)
+    end
+
+    for k in 1:4
+        @test results[k] ≈ f(A, B)
+    end
+end


### PR DESCRIPTION
This should close #14 

I refactor the design of `preallocate` here, the old API will cause type instability, and I think there is actually no use case that a user will want to only run once of the function they put into `preallocate`, thus it makes sense to actually just run it right after `preallocate` is called. 

Moreover, I think in most cases, we should just `freeze` the record for `preallocate` cause, since users are not supposed to touch what's inside this `PreallocatedMethod` struct (which is not part of the API), which also make things more type stable (I find type stability matters a lot in allocations.)

But one thing I still don't understand is why `step[] = 1` is not type stable? this is so strange...