### PR TITLE
Always reinitialize

### DIFF
--- a/src/preallocate.jl
+++ b/src/preallocate.jl
@@ -11,7 +11,7 @@ end
 
 function (f::PreallocatedMethod)(xs...)
     ctx = f.replay_ctxs[Threads.threadid()]
-    ctx.metadata.step[] = 1
+    reinitialize!(ctx.metadata)
     return Cassette.overdub(ctx, f.f, xs...)
 end
 

--- a/src/record_types.jl
+++ b/src/record_types.jl
@@ -40,15 +40,18 @@ function reinitialize!(record)
     for ii in eachindex(record.allocations)
         alloc = record.allocations[ii]
         sz = record.initial_sizes[ii]
-
-        # only vectors can be resized, and
-        # don't check `size(alloc)` as this allocates, unlike `length(alloc)`
-        if ndims(alloc) == 1 && length(alloc) !== first(sz)
-            # fix any vectors that were e.g. `push!`ed to.
-            resize!(alloc, sz...)
-        end
+        reinit!(alloc, sz)  # function barrier here prevents allocations
     end
     return record
+end
+
+function reinit!(alloc, sz)  # this is a function barrier for inside `reinitialize!`
+    # only vectors can be resized, and
+    # don't check `size(alloc)` as this allocates, unlike `length(alloc)`
+    if ndims(alloc) == 1 && length(alloc) !== first(sz)
+        # fix any vectors that were e.g. `push!`ed to.
+        resize!(alloc, first(sz))
+    end
 end
 
 # This can be use to write the record to file so that one can reuse it.

--- a/src/record_types.jl
+++ b/src/record_types.jl
@@ -40,7 +40,10 @@ function reinitialize!(record)
     for ii in eachindex(record.allocations)
         alloc = record.allocations[ii]
         sz = record.initial_sizes[ii]
-        if size(alloc) !== sz
+
+        # only vectors can be resized, and
+        # don't check `size(alloc)` as this allocates, unlike `length(alloc)`
+        if ndims(alloc) == 1 && length(alloc) !== first(sz)
             # fix any vectors that were e.g. `push!`ed to.
             resize!(alloc, sz...)
         end

--- a/test/integration_tests.jl
+++ b/test/integration_tests.jl
@@ -50,3 +50,20 @@ end
         @test results[k] ≈ f(As[k], Bs[k])
     end
 end
+
+@testset "resizing operations" begin
+    function push_pop_test(a)
+        x = [0, 0, 0]
+        @test length(x) == 3
+        push!(x, a)
+        push!(x, 10a)
+        @test length(x) == 5
+        pop!(x)
+        @test length(x) == 4
+    end
+
+    _, p_push_pop_test = preallocate(push_pop_test, 1)
+    p_push_pop_test(2)  # check works on second call
+    p_push_pop_test(3)  # check works on third call
+    p_push_pop_test(4)  # check works on fourth call
+end


### PR DESCRIPTION
My original intent was that `reinitialize` alway was called before starting.
However, I couldn't make it fast and nonallocating when i first tried to do so.
But this PR does.


```julia
julia> @btime reinitialize!($record)
  44.126 ns (0 allocations: 0 bytes)
AutoPreallocation.AllocationRecord(
    [Array{Float64,1}(undef, (64,))],
    [(64,)]
)

julia> @btime reinitialize!($(freeze(record)))
  4.078 ns (0 allocations: 0 bytes)
```
Freezing really pays off for reinitialize.
As it can remove the checks base on the types


This removes the need to document anything special to do with `push!`/`pop!` in #18